### PR TITLE
fix(registration): propagate returnUrl through registration flow and …

### DIFF
--- a/src/Codx.Auth/Controllers/AccountController.cs
+++ b/src/Codx.Auth/Controllers/AccountController.cs
@@ -44,6 +44,7 @@ namespace Codx.Auth.Controllers
         private readonly IInvitationService _invitationService;
         private readonly IDataProtectionProvider _dataProtection;
         private readonly IAuditService _auditService;
+        private readonly IWorkspaceInitializationService _workspaceInitService;
 
         public AccountController(
             UserManager<ApplicationUser> userManager,
@@ -57,7 +58,8 @@ namespace Codx.Auth.Controllers
             IOptions<AuthenticationSettings> authSettings,
             IInvitationService invitationService,
             IDataProtectionProvider dataProtection,
-            IAuditService auditService)
+            IAuditService auditService,
+            IWorkspaceInitializationService workspaceInitService)
         {
             _userManager = userManager;
             _signInManager = signInManager;
@@ -71,6 +73,7 @@ namespace Codx.Auth.Controllers
             _invitationService = invitationService;
             _dataProtection = dataProtection;
             _auditService = auditService;
+            _workspaceInitService = workspaceInitService;
         }
 
         // ─── Invitation landing ──────────────────────────────────────────────
@@ -257,13 +260,19 @@ namespace Codx.Auth.Controllers
                             protocol: Request.Scheme);
                         var (emailSuccess, _) = await _accountService.SendEmailVerificationAsync(user, callbackUrl);
                         if (emailSuccess)
-                            return RedirectToAction("EmailVerificationSent", new { email = user.Email });
+                            return RedirectToAction("EmailVerificationSent", new { email = user.Email, returnUrl = model.ReturnUrl });
                         ModelState.AddModelError(string.Empty, "Account created but failed to send verification email. Please contact support.");
                     }
                     else
                     {
                         var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
                         await _userManager.ConfirmEmailAsync(user, token);
+                        var autoConfirmContext = await _interaction.GetAuthorizationContextAsync(model.ReturnUrl);
+                        if (autoConfirmContext != null)
+                        {
+                            await _workspaceInitService.InitializeUserForApplicationAsync(
+                                user, autoConfirmContext.Client.ClientId, HttpContext.RequestAborted);
+                        }
                         TempData["RegistrationSuccess"] = "Your account has been created successfully. You can now sign in.";
                         return RedirectToAction("Login", new { returnUrl = model.ReturnUrl });
                     }
@@ -331,7 +340,17 @@ namespace Codx.Auth.Controllers
             }
 
             var result = await _userManager.ConfirmEmailAsync(user, token);
-            
+
+            if (result.Succeeded && !string.IsNullOrEmpty(returnUrl))
+            {
+                var authContext = await _interaction.GetAuthorizationContextAsync(returnUrl);
+                if (authContext != null)
+                {
+                    await _workspaceInitService.InitializeUserForApplicationAsync(
+                        user, authContext.Client.ClientId, HttpContext.RequestAborted);
+                }
+            }
+
             var model = new EmailConfirmedViewModel
             {
                 Success = result.Succeeded,

--- a/src/Codx.Auth/Services/Interfaces/IWorkspaceInitializationService.cs
+++ b/src/Codx.Auth/Services/Interfaces/IWorkspaceInitializationService.cs
@@ -1,0 +1,19 @@
+using Codx.Auth.Data.Entities.AspNet;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Codx.Auth.Services.Interfaces
+{
+    public interface IWorkspaceInitializationService
+    {
+        /// <summary>
+        /// Assigns the default application role to a newly registered user,
+        /// scoped to their personal workspace (tenant + company).
+        /// No-ops gracefully if no application_id or default role is configured.
+        /// </summary>
+        Task InitializeUserForApplicationAsync(
+            ApplicationUser user,
+            string clientId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Codx.Auth/Services/WorkspaceInitializationService.cs
+++ b/src/Codx.Auth/Services/WorkspaceInitializationService.cs
@@ -1,0 +1,139 @@
+using Codx.Auth.Data.Contexts;
+using Codx.Auth.Data.Entities.AspNet;
+using Codx.Auth.Data.Entities.Enterprise;
+using Codx.Auth.Services.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Codx.Auth.Services
+{
+    public class WorkspaceInitializationService : IWorkspaceInitializationService
+    {
+        private readonly UserDbContext _userDbContext;
+        private readonly IdentityServerDbContext _isDbContext;
+        private readonly IAuditService _auditService;
+        private readonly ILogger<WorkspaceInitializationService> _logger;
+
+        public WorkspaceInitializationService(
+            UserDbContext userDbContext,
+            IdentityServerDbContext isDbContext,
+            IAuditService auditService,
+            ILogger<WorkspaceInitializationService> logger)
+        {
+            _userDbContext = userDbContext;
+            _isDbContext = isDbContext;
+            _auditService = auditService;
+            _logger = logger;
+        }
+
+        public async Task InitializeUserForApplicationAsync(
+            ApplicationUser user,
+            string clientId,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                // Step 1: Resolve the EnterpriseApplication.Id from the OIDC client's application_id property.
+                var appId = await _isDbContext.ClientProperties
+                    .Where(cp => cp.Key == "application_id" && cp.Client.ClientId == clientId)
+                    .Select(cp => cp.Value)
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                if (string.IsNullOrEmpty(appId))
+                {
+                    _logger.LogInformation(
+                        "WorkspaceInitializationService: client '{ClientId}' has no application_id property. Skipping workspace init for user {UserId}.",
+                        clientId, user.Id);
+                    return;
+                }
+
+                // Step 2: Load the EnterpriseApplication.
+                var application = await _userDbContext.EnterpriseApplications
+                    .FirstOrDefaultAsync(a => a.Id == appId && a.IsActive, cancellationToken);
+
+                if (application == null)
+                {
+                    _logger.LogWarning(
+                        "WorkspaceInitializationService: EnterpriseApplication '{AppId}' not found or inactive. Skipping workspace init for user {UserId}.",
+                        appId, user.Id);
+                    return;
+                }
+
+                // Step 3: Load the default role for this application.
+                var defaultRole = await _userDbContext.EnterpriseApplicationRoles
+                    .Where(r => r.ApplicationId == appId && r.IsDefault && r.IsActive)
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                if (defaultRole == null)
+                {
+                    _logger.LogInformation(
+                        "WorkspaceInitializationService: No default active role configured for application '{AppId}'. Skipping workspace init for user {UserId}.",
+                        appId, user.Id);
+                    return;
+                }
+
+                // Step 4: Load the company-scoped UserMembership for this user.
+                var membership = await _userDbContext.UserMemberships
+                    .Where(m => m.UserId == user.Id && m.CompanyId != null)
+                    .OrderByDescending(m => m.JoinedAt)
+                    .FirstOrDefaultAsync(cancellationToken);
+
+                if (membership == null)
+                {
+                    _logger.LogWarning(
+                        "WorkspaceInitializationService: No company-scoped membership found for user {UserId}. Skipping workspace init.",
+                        user.Id);
+                    return;
+                }
+
+                // Step 5: Idempotency check — do not insert a duplicate role assignment.
+                var alreadyAssigned = await _userDbContext.UserApplicationRoles
+                    .AnyAsync(
+                        r => r.UserId == user.Id
+                             && r.ApplicationId == appId
+                             && r.TenantId == membership.TenantId
+                             && r.CompanyId == membership.CompanyId.Value,
+                        cancellationToken);
+
+                if (alreadyAssigned)
+                {
+                    return;
+                }
+
+                // Step 6: Insert the default role assignment.
+                var roleAssignment = new UserApplicationRole
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = user.Id,
+                    TenantId = membership.TenantId,
+                    CompanyId = membership.CompanyId.Value,
+                    ApplicationId = appId,
+                    RoleId = defaultRole.Id,
+                    AssignedAt = DateTime.UtcNow,
+                    AssignedByUserId = user.Id
+                };
+
+                await _userDbContext.UserApplicationRoles.AddAsync(roleAssignment, cancellationToken);
+                await _userDbContext.SaveChangesAsync(cancellationToken);
+
+                // Step 7: Audit.
+                await _auditService.LogAsync(
+                    "WorkspaceRoleInitialized",
+                    userId: user.Id,
+                    actorUserId: user.Id,
+                    tenantId: membership.TenantId,
+                    companyId: membership.CompanyId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "WorkspaceInitializationService: Unexpected error during workspace init for user {UserId} via client '{ClientId}'. Registration will continue.",
+                    user.Id, clientId);
+            }
+        }
+    }
+}

--- a/src/Codx.Auth/Startup.cs
+++ b/src/Codx.Auth/Startup.cs
@@ -96,6 +96,7 @@ namespace Codx.Auth
             services.AddScoped<IWorkspaceSessionStore, EfWorkspaceSessionStore>();
             services.AddScoped<IAuditService, DbAuditService>();
             services.AddScoped<IInvitationService, InvitationService>();
+            services.AddScoped<IWorkspaceInitializationService, WorkspaceInitializationService>();
             services.AddHostedService<InvitationExpiryService>();
             services.AddProblemDetails();
 

--- a/src/Codx.Auth/Views/Account/EmailConfirmed.cshtml
+++ b/src/Codx.Auth/Views/Account/EmailConfirmed.cshtml
@@ -37,6 +37,35 @@
                             </div>
                         </div>
 
+                        @if (!string.IsNullOrEmpty(Model.ReturnUrl))
+                        {
+                            var loginUrl = Url.Action("Login", "Account", new { returnUrl = Model.ReturnUrl });
+                            <p class="text-muted">
+                                Redirecting you back to the application in <span id="redirect-countdown">5</span> seconds...
+                            </p>
+                            <div id="auto-redirect"
+                                 data-url="@loginUrl"
+                                 data-seconds="5"
+                                 style="display:none;">
+                            </div>
+                            <script>
+                                (function () {
+                                    var el = document.getElementById('auto-redirect');
+                                    var target = el.getAttribute('data-url');
+                                    var countdown = parseInt(el.getAttribute('data-seconds'), 10);
+                                    var display = document.getElementById('redirect-countdown');
+                                    var interval = setInterval(function () {
+                                        countdown--;
+                                        if (display) display.textContent = countdown;
+                                        if (countdown <= 0) {
+                                            clearInterval(interval);
+                                            window.location.href = target;
+                                        }
+                                    }, 1000);
+                                })();
+                            </script>
+                        }
+
                         <div class="d-grid gap-2">
                             <a asp-action="Login" asp-route-returnUrl="@Model.ReturnUrl" class="btn btn-success btn-lg">
                                 <i class="fas fa-sign-in-alt me-2"></i>

--- a/src/Codx.Auth/Views/Account/EmailVerificationSent.cshtml
+++ b/src/Codx.Auth/Views/Account/EmailVerificationSent.cshtml
@@ -56,6 +56,7 @@
                     <div class="text-center mt-4">
                         <form asp-action="ResendEmailVerification" method="post" class="d-inline">
                             <input type="hidden" name="email" value="@Model.Email" />
+                            <input type="hidden" name="returnUrl" value="@Model.ReturnUrl" />
                             <button type="submit" class="btn btn-outline-secondary">
                                 <i class="fas fa-redo me-2"></i>
                                 Resend Verification Email
@@ -63,14 +64,14 @@
                         </form>
                     </div>
 
-                    <hr class="my-4">
+                    <!-- <hr class="my-4">
 
                     <div class="text-center">
-                        <a asp-action="Login" class="btn btn-primary">
+                        <a asp-action="Login" asp-route-returnUrl="@Model.ReturnUrl" class="btn btn-primary">
                             <i class="fas fa-sign-in-alt me-2"></i>
                             Go to Login
                         </a>
-                    </div>
+                    </div> -->
                 </div>
             </div>
 

--- a/src/Codx.Auth/Views/Account/Login.cshtml
+++ b/src/Codx.Auth/Views/Account/Login.cshtml
@@ -65,7 +65,10 @@
                             <button class="btn btn-secondary" name="button" value="cancel">Cancel</button>
                         </form>
                         <div class="mt-3">
-                            <a asp-controller="Account" asp-action="Register" class="register-link-small">Don't have an account? Register</a>
+                            <a asp-controller="Account"
+                               asp-action="Register"
+                               asp-route-returnUrl="@Model.ReturnUrl"
+                               class="register-link-small">Don't have an account? Register</a>
                         </div>
 
                         <hr />


### PR DESCRIPTION
Fixes three related bugs in the registration flow where the return URL from the originating OIDC client was being dropped at the Register link, causing users to never be redirected back to the application they registered from. Additionally introduces WorkspaceInitializationService to automatically assign the configured default application role to newly registered users.