### PR TITLE
fix(workspace-token): cascade tenant membership roles into workspace_…

### DIFF
--- a/src/Codx.Auth/Extensions/CustomProfileService.cs
+++ b/src/Codx.Auth/Extensions/CustomProfileService.cs
@@ -353,13 +353,23 @@ namespace Codx.Auth.Extensions
 
             if (membership == null) return;
 
-            var roleCodes = await _userDb.UserMembershipRoles
-                .AsNoTracking()
-                .Where(umr => umr.MembershipId == membership.Id && umr.Status == "Active")
+            // Cascade: union roles from the company-level membership and the parent
+            // tenant-level membership (CompanyId == null) within this tenant.
+            var roleCodes = await _userDb.UserMemberships.AsNoTracking()
+                .Where(m =>
+                    m.UserId == user.Id &&
+                    m.TenantId == session.TenantId &&
+                    (m.CompanyId == session.CompanyId || m.CompanyId == null) &&
+                    m.Status == LifecycleStatus.Membership.Active)
+                .Join(_userDb.UserMembershipRoles.Where(umr => umr.Status == LifecycleStatus.MembershipRole.Active),
+                    m => m.Id,
+                    umr => umr.MembershipId,
+                    (m, umr) => umr)
                 .Join(_userDb.WorkspaceRoleDefinitions.Where(wrd => wrd.Status == LifecycleStatus.RoleDefinition.Active),
                     umr => umr.RoleId,
                     wrd => wrd.Id,
                     (umr, wrd) => wrd.Code)
+                .Distinct()
                 .ToListAsync();
 
             _workspaceContext.UserId = user.Id;

--- a/src/Codx.Auth/Extensions/WorkspaceContextValidator.cs
+++ b/src/Codx.Auth/Extensions/WorkspaceContextValidator.cs
@@ -155,12 +155,23 @@ namespace Codx.Auth.Extensions
                             return;
                         }
 
-            var existingRoleCodes = await _db.UserMembershipRoles.AsNoTracking()
-                            .Where(umr => umr.MembershipId == existingMembership.Id && umr.Status == LifecycleStatus.MembershipRole.Active)
+                        // Cascade: union roles from both the company-level membership and the
+                        // parent tenant-level membership (CompanyId == null) within this tenant.
+                        var existingRoleCodes = await _db.UserMemberships.AsNoTracking()
+                            .Where(m =>
+                                m.UserId == userId &&
+                                m.TenantId == existingSession.TenantId &&
+                                (m.CompanyId == existingSession.CompanyId || m.CompanyId == null) &&
+                                m.Status == LifecycleStatus.Membership.Active)
+                            .Join(_db.UserMembershipRoles.Where(umr => umr.Status == LifecycleStatus.MembershipRole.Active),
+                                m => m.Id,
+                                umr => umr.MembershipId,
+                                (m, umr) => umr)
                             .Join(_db.WorkspaceRoleDefinitions.Where(wrd => wrd.Status == LifecycleStatus.RoleDefinition.Active),
                                 umr => umr.RoleId,
                                 wrd => wrd.Id,
                                 (umr, wrd) => wrd.Code)
+                            .Distinct()
                             .ToListAsync();
 
                         // Renew the session so it stays alive across back-to-back token refreshes.
@@ -296,13 +307,24 @@ namespace Codx.Auth.Extensions
                 return;
             }
 
-            // --- Resolve workspace role codes ---
-            var roleCodes = await _db.UserMembershipRoles.AsNoTracking()
-                .Where(umr => umr.MembershipId == membership.Id && umr.Status == LifecycleStatus.MembershipRole.Active)
+            // --- Resolve workspace role codes (tenant-level cascade) ---
+            // Union roles from the company-level membership and the parent tenant-level membership
+            // (CompanyId == null within this tenant). Identical role codes are deduplicated.
+            var roleCodes = await _db.UserMemberships.AsNoTracking()
+                .Where(m =>
+                    m.UserId == userId &&
+                    m.TenantId == tenantId &&
+                    (m.CompanyId == companyId || m.CompanyId == null) &&
+                    m.Status == LifecycleStatus.Membership.Active)
+                .Join(_db.UserMembershipRoles.Where(umr => umr.Status == LifecycleStatus.MembershipRole.Active),
+                    m => m.Id,
+                    umr => umr.MembershipId,
+                    (m, umr) => umr)
                 .Join(_db.WorkspaceRoleDefinitions.Where(wrd => wrd.Status == LifecycleStatus.RoleDefinition.Active),
                     umr => umr.RoleId,
                     wrd => wrd.Id,
                     (umr, wrd) => wrd.Code)
+                .Distinct()
                 .ToListAsync();
 
             // --- Session exclusivity: revoke any existing active session, then create a new one ---


### PR DESCRIPTION
## Summary

When issuing a workspace-scoped `access_token`, the `workspace_role` claim was populated only from the user's company-level `UserMembership`, silently dropping any roles assigned at the parent tenant level. This fix unions the company-level and tenant-level (`CompanyId = NULL`) membership roles — with deduplication — across all three role-resolution paths in the token issuance pipeline.

## Changes

- fix: update Phase 2 workspace token path in `WorkspaceContextValidator` to union company + tenant-level membership roles with `.Distinct()`
- fix: update silent-refresh path in `WorkspaceContextValidator` to apply the same cascade union query
- fix: update DB-fallback path in `CustomProfileService` to apply the same cascade union query and replace raw `"Active"` string literals with `LifecycleStatus` constants

## Type

fix

## Affected Project(s)

Codx.Auth

## Related Issue

None

## Notes for Reviewer

- **Three resolution sites updated:** (1) `WorkspaceContextValidator` Phase 2 upgrade flow, (2) `WorkspaceContextValidator` silent-refresh flow, (3) `CustomProfileService` DB-fallback path (snapshot absent from `HttpContext.Items`).
- **No schema changes, no EF Core migrations.** Read-side change only — new query joins `UserMemberships → UserMembershipRoles → WorkspaceRoleDefinitions` filtered by `(CompanyId = @company OR CompanyId IS NULL) AND TenantId = @tenant`.
- **`MembershipResolver.ResolveWorkspaceRolesAsync`** is a general-purpose utility not in the token issuance pipeline — intentionally left unchanged.
- **Existing access tokens are unaffected** until they expire; tenant roles will appear on the next token issuance after this deployment.
- Cross-tenant isolation is preserved: the `TenantId` predicate ensures only the tenant that owns the target company is queried.