### PR TITLE
Email Template Guide

### DIFF
--- a/docs/user-manual-doc.md
+++ b/docs/user-manual-doc.md
@@ -22,6 +22,7 @@
 13. [End-to-End Example: Setting Up Personnel Management](#13-end-to-end-example-setting-up-personnel-management)
 14. [SPA Integration Reference](#14-spa-integration-reference)
 15. [Troubleshooting: No Roles in Access Token](#15-troubleshooting-no-roles-in-access-token)
+16. [Section: Email Templates](#16-section-email-templates)
 
 ---
 
@@ -1126,3 +1127,218 @@ WHERE ApplicationId = 'personnel-management';
 | Token request rejected                   | Tenant or Company inactive                | Set Status to Active                                                                                                 |
 | 403 on API                               | Wrong `audience` in API's JWT validation  | Set `Audience = "personnel-management"` (matching `ApiResource.Name`)                                                |
 | 403 on `POST /user-roles`                | Caller lacks admin workspace role         | Token must contain `workspace_role: CompanyAdmin` or `TenantAdmin`                                                   |
+
+---
+
+## 16. Section: Email Templates
+
+**Route:** `/EmailTemplates`
+**Required Role:** `PlatformAdmin` (global templates) or `TenantOwner` / `TenantAdmin` (tenant-level overrides)
+
+### Purpose
+
+The **Email Templates** section lets administrators customise the HTML email bodies sent for identity events — email verification, two-factor authentication, password reset, and user invitations. If no custom template is configured, the system always falls back to a built-in hardcoded default.
+
+---
+
+### Template Resolution Order
+
+For every outgoing identity email, Codx.Auth evaluates templates in this priority order:
+
+```
+1. Tenant override    — A custom template stored for the specific tenant
+2. Global default     — A platform-wide custom template (applies to all tenants without an override)
+3. Built-in default   — Hardcoded fallback; always available and cannot be deleted
+```
+
+If step 1 is not found, the system moves to step 2. If step 2 is not found, it falls through to step 3. Step 3 always succeeds.
+
+---
+
+### Supported Template Types
+
+| Type                | Display Name         | Triggered When                                           | Required Placeholder    |
+| ------------------- | -------------------- | -------------------------------------------------------- | ----------------------- |
+| `EmailVerification` | Verification Email   | A new user registers or requests a new verification link | `{{VerificationLink}}`  |
+| `TwoFactor`         | Two-Factor Email     | A user with email-based 2FA signs in                     | `{{TwoFactorCode}}`     |
+| `PasswordReset`     | Password Reset Email | A user submits the "Forgot Password" form                | `{{PasswordResetLink}}` |
+| `Invitation`        | Invitation Email     | An admin invites a new user to a tenant or company       | `{{InvitationLink}}`    |
+
+---
+
+### Placeholder Reference
+
+Tokens are replaced with real values when the email is sent. Tokens are **case-sensitive** and use double-brace syntax.
+
+| Token                   | Required | Applies To        | Description                                                                        |
+| ----------------------- | -------- | ----------------- | ---------------------------------------------------------------------------------- |
+| `{{VerificationLink}}`  | **Yes**  | EmailVerification | One-click URL to verify the user's email address                                   |
+| `{{TwoFactorCode}}`     | **Yes**  | TwoFactor         | Short-lived numeric authentication code                                            |
+| `{{PasswordResetLink}}` | **Yes**  | PasswordReset     | URL the user clicks to navigate to the reset-password form. Expires in **1 hour**. |
+| `{{InvitationLink}}`    | **Yes**  | Invitation        | URL the recipient follows to accept the invitation                                 |
+| `{{UserName}}`          | No       | All types         | Recipient's display name                                                           |
+| `{{UserEmail}}`         | No       | All types         | Recipient's email address                                                          |
+| `{{TenantName}}`        | No       | All types         | Name of the tenant the user belongs to                                             |
+| `{{CompanyName}}`       | No       | All types         | Name of the active company                                                         |
+| `{{InviterName}}`       | No       | Invitation        | Display name of the user who sent the invitation                                   |
+
+> **Validation rule:** A template body that omits the required placeholder for its type **cannot be saved**. The editor displays a validation error identifying the missing token.
+
+> **Unrecognized tokens:** Any `{{…}}` token not in the known set is shown as a **warning** in the live preview but does not block saving. Unrecognized tokens are left unreplaced in the sent email (they appear literally).
+
+---
+
+### Password Reset Email — Detailed Guide
+
+The Password Reset Email is sent when a user submits the **Forgot Password** form. The system resolves the template for the user's primary tenant before sending.
+
+#### Required placeholder
+
+`{{PasswordResetLink}}` — the full URL pointing to the reset-password form with the user's encoded reset token embedded. The link **expires in 1 hour**. If the user does not act within that window, they must submit the Forgot Password form again to receive a new link.
+
+#### Optional placeholders
+
+`{{UserName}}`, `{{UserEmail}}`, `{{TenantName}}`, `{{CompanyName}}`
+
+#### Built-in default body
+
+The following is the raw HTML source of the built-in default. Copy it as a starting point for your custom template.
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Password Reset</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        line-height: 1.6;
+        color: #333;
+        max-width: 600px;
+        margin: 0 auto;
+        padding: 20px;
+      }
+      .header {
+        background-color: #dc3545;
+        color: white;
+        padding: 20px;
+        text-align: center;
+        border-radius: 5px 5px 0 0;
+      }
+      .content {
+        background-color: #f8f9fa;
+        padding: 30px;
+        border-radius: 0 0 5px 5px;
+      }
+      .button {
+        display: inline-block;
+        padding: 15px 30px;
+        background-color: #dc3545;
+        color: white;
+        text-decoration: none;
+        border-radius: 5px;
+        margin: 20px 0;
+        font-weight: bold;
+      }
+      .warning {
+        background-color: #fff3cd;
+        border: 1px solid #ffeaa7;
+        border-radius: 5px;
+        padding: 15px;
+        margin: 20px 0;
+      }
+      .footer {
+        text-align: center;
+        margin-top: 30px;
+        font-size: 12px;
+        color: #6c757d;
+      }
+      .link {
+        word-break: break-all;
+        color: #dc3545;
+        font-size: 12px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="header">
+      <h1>Password Reset Request</h1>
+    </div>
+    <div class="content">
+      <h2>Hello {{UserName}},</h2>
+      <p>
+        We received a request to reset the password for your account. Click the
+        button below to set a new password:
+      </p>
+
+      <div style="text-align: center;">
+        <a href="{{PasswordResetLink}}" class="button">Reset Password</a>
+      </div>
+
+      <div class="warning">
+        <strong>Important:</strong>
+        <ul>
+          <li>This link will expire in 1 hour</li>
+          <li>
+            If you did not request a password reset, please ignore this email
+            and your password will remain unchanged
+          </li>
+          <li>Do not share this link with anyone</li>
+        </ul>
+      </div>
+
+      <p>
+        If the button above doesn't work, copy and paste the following link into
+        your browser:
+      </p>
+      <p class="link">{{PasswordResetLink}}</p>
+
+      <p>Best regards,<br />Codx Auth Team</p>
+    </div>
+    <div class="footer">
+      <p>This is an automated message. Please do not reply to this email.</p>
+      <p>If you have any questions, please contact our support team.</p>
+    </div>
+  </body>
+</html>
+```
+
+> **Live preview note:** In the editor preview, `{{PasswordResetLink}}` is replaced with a sample URL and `{{UserName}}` with `"John Doe"`. The preview does not send an actual email.
+
+---
+
+### Step-by-Step: Customising the Global Password Reset Email (Platform Admin)
+
+1. Navigate to **Email Templates** (`/EmailTemplates`).
+2. Locate the **"Password Reset Email"** row. The **Source** column shows `Built-in` if no custom template has been configured yet.
+3. Click **Edit**.
+4. Replace the body with your HTML. Ensure `{{PasswordResetLink}}` is present.
+5. Optionally include `{{UserName}}`, `{{UserEmail}}`, `{{TenantName}}`, or `{{CompanyName}}`.
+6. Click **Preview** to see a rendered sample — warnings appear for any unrecognized tokens.
+7. Click **Save**. All password reset emails now use this body for tenants that have not set their own override. The Source column changes to `Custom`.
+8. To revert to the built-in default at any time, click **Reset** on the template list page.
+
+---
+
+### Step-by-Step: Customising the Tenant-Level Password Reset Email (Tenant Admin)
+
+1. Navigate to **Email Templates** with your tenant context: `/EmailTemplates?tenantId={yourTenantId}`.
+2. Locate the **"Password Reset Email"** row. The **Source** column shows `Global Default` (if the platform has a global template) or `Built-in` (if not).
+3. Click **Edit**, provide your custom HTML body (must include `{{PasswordResetLink}}`), and click **Save**.
+4. Users in your tenant will now receive your tenant-specific password reset email for all future password reset requests.
+5. To remove the override and fall back to the global (or built-in) default, click **Reset**.
+
+> **Isolation rule:** Tenant Admins can only manage templates for their own tenant. The `tenantId` query parameter must match the `tenant_id` claim in their JWT. A mismatch returns `403 Forbidden` regardless of any other claim.
+
+---
+
+### Email Templates Guide Page
+
+Navigate to `/EmailTemplates/Guide` (or click **View Guide** on the template list page) for:
+
+- A complete placeholder reference table for all four template types.
+- The three-level resolution order shown as a flowchart.
+- The raw HTML source of the built-in default body for each type, ready to copy.
+
+The guide page is accessible to any authenticated user — no admin role is required to read it.

--- a/src/Codx.Auth/Controllers/EmailTemplatesController.cs
+++ b/src/Codx.Auth/Controllers/EmailTemplatesController.cs
@@ -21,6 +21,7 @@ namespace Codx.Auth.Controllers
     {
         private readonly IEmailTemplateService _templateService;
         private readonly UserDbContext _db;
+        private readonly BuiltInEmailTemplateProvider _builtIn;
 
         private static readonly Dictionary<string, string> TypeLabels = new()
         {
@@ -30,10 +31,11 @@ namespace Codx.Auth.Controllers
             ["Invitation"]        = "Invitation Email"
         };
 
-        public EmailTemplatesController(IEmailTemplateService templateService, UserDbContext db)
+        public EmailTemplatesController(IEmailTemplateService templateService, UserDbContext db, BuiltInEmailTemplateProvider builtIn)
         {
             _templateService = templateService;
             _db = db;
+            _builtIn = builtIn;
         }
 
         // GET /EmailTemplates           — Platform Admin (global)
@@ -268,6 +270,19 @@ namespace Codx.Auth.Controllers
 
             var result = _templateService.RenderPreview(templateType, body);
             return Json(new { rendered = result.Rendered, warnings = result.UnrecognizedPlaceholders });
+        }
+
+        // GET /EmailTemplates/Guide
+        [HttpGet("Guide")]
+        public IActionResult Guide()
+        {
+            return View(new EmailTemplateGuideViewModel
+            {
+                EmailVerificationDefaultBody = _builtIn.GetEmailVerificationBody("{{UserName}}", "{{VerificationLink}}"),
+                TwoFactorDefaultBody         = _builtIn.GetTwoFactorBody("{{UserName}}", "{{TwoFactorCode}}"),
+                PasswordResetDefaultBody     = _builtIn.GetPasswordResetBody("{{UserName}}", "{{PasswordResetLink}}"),
+                InvitationDefaultBody        = _builtIn.GetInvitationBody("{{UserName}}", "{{InviterName}}", "{{InvitationLink}}")
+            });
         }
 
         // ── Helpers ──────────────────────────────────────────────────────────

--- a/src/Codx.Auth/ViewModels/EmailTemplates/EmailTemplateGuideViewModel.cs
+++ b/src/Codx.Auth/ViewModels/EmailTemplates/EmailTemplateGuideViewModel.cs
@@ -1,0 +1,10 @@
+namespace Codx.Auth.ViewModels.EmailTemplates
+{
+    public class EmailTemplateGuideViewModel
+    {
+        public string EmailVerificationDefaultBody { get; set; } = string.Empty;
+        public string TwoFactorDefaultBody         { get; set; } = string.Empty;
+        public string PasswordResetDefaultBody     { get; set; } = string.Empty;
+        public string InvitationDefaultBody        { get; set; } = string.Empty;
+    }
+}

--- a/src/Codx.Auth/Views/EmailTemplates/Guide.cshtml
+++ b/src/Codx.Auth/Views/EmailTemplates/Guide.cshtml
@@ -1,0 +1,238 @@
+@model Codx.Auth.ViewModels.EmailTemplates.EmailTemplateGuideViewModel
+
+@{
+    ViewData["Title"] = "Email Templates — Guide";
+}
+
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item"><a href="@Url.Action("Index", "Home")">Home</a></li>
+        <li class="breadcrumb-item"><a asp-controller="EmailTemplates" asp-action="Index">Email Templates</a></li>
+        <li class="breadcrumb-item active" aria-current="page">Guide</li>
+    </ol>
+</nav>
+
+<div class="row">
+    <div class="col-lg-10">
+
+        <div class="card mb-4">
+            <div class="card-header">
+                <h5 class="mb-0">Email Templates — Administrator Guide</h5>
+            </div>
+            <div class="card-body">
+                <p>
+                    Codx.Auth sends HTML emails for identity events (email verification, two-factor authentication,
+                    password reset, and user invitations). The body of each email can be customised at the
+                    <strong>platform level</strong> (applies to all tenants) or overridden per
+                    <strong>tenant</strong>.
+                </p>
+
+                <h6 class="mt-4">Template Resolution Order</h6>
+                <p>For every outgoing identity email, the system resolves the body in this order:</p>
+                <ol>
+                    <li><strong>Tenant override</strong> — a custom template saved for the recipient's tenant.</li>
+                    <li><strong>Global default</strong> — a platform-wide custom template (applies to all tenants without an override).</li>
+                    <li><strong>Built-in default</strong> — the hardcoded fallback; always available and cannot be deleted.</li>
+                </ol>
+
+                <h6 class="mt-4">Placeholder Reference</h6>
+                <p>
+                    Placeholders are replaced with real values when the email is sent. They use double-brace syntax
+                    and are <strong>case-sensitive</strong>.
+                </p>
+                <table class="table table-bordered table-sm">
+                    <thead class="table-light">
+                        <tr>
+                            <th>Token</th>
+                            <th>Required</th>
+                            <th>Applies To</th>
+                            <th>Description</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td><code>{{VerificationLink}}</code></td>
+                            <td><span class="badge bg-danger">Required</span></td>
+                            <td>Verification Email</td>
+                            <td>One-click URL to verify the user's email address.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{TwoFactorCode}}</code></td>
+                            <td><span class="badge bg-danger">Required</span></td>
+                            <td>Two-Factor Email</td>
+                            <td>Short-lived numeric authentication code.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{PasswordResetLink}}</code></td>
+                            <td><span class="badge bg-danger">Required</span></td>
+                            <td>Password Reset Email</td>
+                            <td>URL the user clicks to navigate to the reset-password form. Expires in <strong>1 hour</strong>.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{InvitationLink}}</code></td>
+                            <td><span class="badge bg-danger">Required</span></td>
+                            <td>Invitation Email</td>
+                            <td>URL the recipient follows to accept the invitation.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{UserName}}</code></td>
+                            <td><span class="badge bg-secondary">Optional</span></td>
+                            <td>All types</td>
+                            <td>Recipient's display name.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{UserEmail}}</code></td>
+                            <td><span class="badge bg-secondary">Optional</span></td>
+                            <td>All types</td>
+                            <td>Recipient's email address.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{TenantName}}</code></td>
+                            <td><span class="badge bg-secondary">Optional</span></td>
+                            <td>All types</td>
+                            <td>Name of the tenant the user belongs to.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{CompanyName}}</code></td>
+                            <td><span class="badge bg-secondary">Optional</span></td>
+                            <td>All types</td>
+                            <td>Name of the active company.</td>
+                        </tr>
+                        <tr>
+                            <td><code>{{InviterName}}</code></td>
+                            <td><span class="badge bg-secondary">Optional</span></td>
+                            <td>Invitation Email</td>
+                            <td>Display name of the user who sent the invitation.</td>
+                        </tr>
+                    </tbody>
+                </table>
+
+                <div class="alert alert-warning mt-3">
+                    <strong>Validation rules:</strong>
+                    <ul class="mb-0 mt-1">
+                        <li>A template body that omits the <strong>required placeholder</strong> for its type cannot be saved — the editor will show a validation error.</li>
+                        <li>Maximum template body length is <strong>65,536 characters</strong>.</li>
+                        <li>Unrecognized <code>{{…}}</code> tokens appear as <strong>warnings</strong> in the preview but do not block saving. They will appear literally (unreplaced) in sent emails.</li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        @* ── Password Reset Email ─────────────────────────────────────── *@
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h6 class="mb-0">Password Reset Email</h6>
+                <span class="badge bg-secondary">PasswordReset</span>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-3">
+                    <dt class="col-sm-3">Triggered when</dt>
+                    <dd class="col-sm-9">A user submits the <strong>Forgot Password</strong> form.</dd>
+
+                    <dt class="col-sm-3">Required placeholder</dt>
+                    <dd class="col-sm-9">
+                        <code>{{PasswordResetLink}}</code> — the URL the user must click to set a new password.
+                        The link <strong>expires in 1 hour</strong>. If the user does not act within that window,
+                        they must submit the Forgot Password form again.
+                    </dd>
+
+                    <dt class="col-sm-3">Optional placeholders</dt>
+                    <dd class="col-sm-9">
+                        <code>{{UserName}}</code>, <code>{{UserEmail}}</code>,
+                        <code>{{TenantName}}</code>, <code>{{CompanyName}}</code>
+                    </dd>
+
+                    <dt class="col-sm-3">Tenant resolution</dt>
+                    <dd class="col-sm-9">
+                        The template is resolved against the user's <em>primary tenant</em>
+                        (the oldest active membership). A tenant override — if present — takes precedence
+                        over the global default.
+                    </dd>
+                </dl>
+
+                <p class="text-muted mb-1"><strong>Built-in default body</strong> — copy this as a starting point:</p>
+                <pre class="border rounded p-3 bg-light" style="max-height:400px;overflow-y:auto;font-size:0.78rem;">@Model.PasswordResetDefaultBody</pre>
+            </div>
+        </div>
+
+        @* ── Verification Email ───────────────────────────────────────── *@
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h6 class="mb-0">Verification Email</h6>
+                <span class="badge bg-secondary">EmailVerification</span>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-3">
+                    <dt class="col-sm-3">Triggered when</dt>
+                    <dd class="col-sm-9">A new user registers or requests a new email verification link.</dd>
+
+                    <dt class="col-sm-3">Required placeholder</dt>
+                    <dd class="col-sm-9"><code>{{VerificationLink}}</code> — one-click URL to verify the user's email address.</dd>
+
+                    <dt class="col-sm-3">Optional placeholders</dt>
+                    <dd class="col-sm-9">
+                        <code>{{UserName}}</code>, <code>{{UserEmail}}</code>,
+                        <code>{{TenantName}}</code>, <code>{{CompanyName}}</code>
+                    </dd>
+                </dl>
+
+                <p class="text-muted mb-1"><strong>Built-in default body</strong> — copy this as a starting point:</p>
+                <pre class="border rounded p-3 bg-light" style="max-height:400px;overflow-y:auto;font-size:0.78rem;">@Model.EmailVerificationDefaultBody</pre>
+            </div>
+        </div>
+
+        @* ── Two-Factor Email ─────────────────────────────────────────── *@
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h6 class="mb-0">Two-Factor Email</h6>
+                <span class="badge bg-secondary">TwoFactor</span>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-3">
+                    <dt class="col-sm-3">Triggered when</dt>
+                    <dd class="col-sm-9">A user with email-based two-factor authentication signs in.</dd>
+
+                    <dt class="col-sm-3">Required placeholder</dt>
+                    <dd class="col-sm-9"><code>{{TwoFactorCode}}</code> — the short-lived numeric authentication code.</dd>
+
+                    <dt class="col-sm-3">Optional placeholders</dt>
+                    <dd class="col-sm-9">
+                        <code>{{UserName}}</code>, <code>{{UserEmail}}</code>,
+                        <code>{{TenantName}}</code>, <code>{{CompanyName}}</code>
+                    </dd>
+                </dl>
+
+                <p class="text-muted mb-1"><strong>Built-in default body</strong> — copy this as a starting point:</p>
+                <pre class="border rounded p-3 bg-light" style="max-height:400px;overflow-y:auto;font-size:0.78rem;">@Model.TwoFactorDefaultBody</pre>
+            </div>
+        </div>
+
+        @* ── Invitation Email ─────────────────────────────────────────── *@
+        <div class="card mb-4">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <h6 class="mb-0">Invitation Email</h6>
+                <span class="badge bg-secondary">Invitation</span>
+            </div>
+            <div class="card-body">
+                <dl class="row mb-3">
+                    <dt class="col-sm-3">Triggered when</dt>
+                    <dd class="col-sm-9">An admin invites a new user to a tenant or company.</dd>
+
+                    <dt class="col-sm-3">Required placeholder</dt>
+                    <dd class="col-sm-9"><code>{{InvitationLink}}</code> — the URL the recipient follows to accept the invitation.</dd>
+
+                    <dt class="col-sm-3">Optional placeholders</dt>
+                    <dd class="col-sm-9">
+                        <code>{{UserName}}</code>, <code>{{UserEmail}}</code>,
+                        <code>{{TenantName}}</code>, <code>{{CompanyName}}</code>,
+                        <code>{{InviterName}}</code>
+                    </dd>
+                </dl>
+
+                <p class="text-muted mb-1"><strong>Built-in default body</strong> — copy this as a starting point:</p>
+                <pre class="border rounded p-3 bg-light" style="max-height:400px;overflow-y:auto;font-size:0.78rem;">@Model.InvitationDefaultBody</pre>
+            </div>
+        </div>
+
+    </div>
+</div>

--- a/src/Codx.Auth/Views/EmailTemplates/Index.cshtml
+++ b/src/Codx.Auth/Views/EmailTemplates/Index.cshtml
@@ -34,6 +34,7 @@
                 <h5 class="mb-0">
                     @(Model.TenantId.HasValue ? $"{Model.TenantName} — Email Templates" : "Global Email Templates")
                 </h5>
+                <a asp-action="Guide" asp-controller="EmailTemplates" class="btn btn-outline-secondary btn-sm">View Guide</a>
             </div>
             <div class="card-body">
 


### PR DESCRIPTION
## Summary

Adds an in-app Email Templates Guide page (`GET /EmailTemplates/Guide`) to Codx.Auth, surfacing the built-in default body for all four email template types alongside a full placeholder reference and resolution-order documentation. Also updates the external user manual (Section 16) with password reset template guidance.

## Changes

- feat: add `EmailTemplateGuideViewModel` POCO with one property per template type
- feat: inject `BuiltInEmailTemplateProvider` into `EmailTemplatesController` and add `GET /EmailTemplates/Guide` action
- feat: create `Views/EmailTemplates/Guide.cshtml` — placeholder reference table, resolution-order explanation, per-type sections with copy-pasteable built-in default bodies
- feat: add "View Guide" button to `Views/EmailTemplates/Index.cshtml` card header
- docs: add Section 16 (Email Templates) to `docs/user-manual-doc.md` covering the PasswordReset template type, required/optional placeholders, and resolution order

## Type

feat

## Related Issue

None

## Notes for Reviewer

- Built-in default bodies are rendered using Razor's default `@` HTML encoding (NOT `@Html.Raw`) — the HTML source is displayed safely as text for copy-paste, not rendered as live HTML.
- `BuiltInEmailTemplateProvider` is called with token strings as arguments (e.g., `"{{UserName}}"`) so the displayed body already contains the placeholder tokens — ready to copy and paste into the editor.
- No DB migrations, no new entities, no auth changes — the `PasswordReset` template type was already fully wired for global and tenant-level editing by spec 003 + spec 006.